### PR TITLE
change phase of port reservation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -550,7 +550,7 @@
                                 <goals>
                                     <goal>reserve-network-port</goal>
                                 </goals>
-                                <phase>process-test-classes</phase>
+                                <phase>process-test-resources</phase>
                                 <configuration>
                                     <portNames>
                                         <portName>jetty.server.port</portName>


### PR DESCRIPTION
on jdk8 it worked fine, but with jdk11 the port reservation is not called and the standard port 8080 was used.