### PR TITLE
update frontend-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.10.0</version>
+                    <version>1.12.1</version>
                     <configuration>
                         <nodeVersion>v14.15.1</nodeVersion>
                         <npmVersion>6.14.9</npmVersion>


### PR DESCRIPTION
update frontend-maven-plugin for npx support. otherwise builds with jsdoc@3.6.9 dep break on systems without own node installation.