### PR TITLE
Update jetty version to 9.4.44.v20210927

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
                 <plugin>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
-                    <version>9.4.17.v20190418</version>
+                    <version>9.4.44.v20210927</version>
                     <configuration>
                         <supportedPackagings>
                             <supportedPackaging>jar</supportedPackaging>


### PR DESCRIPTION
Update jetty version to 9.4.44.v20210927 to fix unresponsive server on amd systems.