### PR TITLE
Add vs code extensions recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+        "vue.volar"
+    ]
+}


### PR DESCRIPTION
This PR adds the `extensions.json` file to the `.vscode` folder. This enables the repository to [recommend](https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions) certain vs code extensions. But those extensions are not enforced. The recommendations will appear on the first opening of the folder in vs code as a notification in the right bottom corner. Afterwards it is possible to review them on typing `@recommended` in the extension search bar.
This PR includes two basic extensions:

- [Vue Language Features (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.volar) - this extension is [recommended](https://vuejs.org/guide/typescript/overview.html#ide-support) and created by vue
- [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) - this extension is [recommended](https://eslint.org/docs/latest/use/integrations#editors) by eslint

The benefit of this curated extension list is that the user has to do less work to setup its vs code installation to get better developer experience. It also allows to tweak the map.apps documentation...

Side note: If someone else wants to extend this list. The easiest way is to go to the extensions tab. Than click on the gear icon of the extension you want to add. Than click on "Add to Workspace Recommendations" which adds this extensions to the `extensions.json` file.

@matthiasstein @sholtkamp 